### PR TITLE
Add more detail to the release note

### DIFF
--- a/additional_notes/0.6.0/header.md
+++ b/additional_notes/0.6.0/header.md
@@ -1,6 +1,4 @@
 
-*Thu, Apr 10, 2025*
-
 🚧 *These notes are under construction while in pre-release* 🚧
 
 We’re happy to announce the release of napari 0.6.0! The right-handed release! This release features major changes so read on to see how they might affect you!

--- a/additional_notes/0.6.0/header.md
+++ b/additional_notes/0.6.0/header.md
@@ -1,5 +1,5 @@
 
-*Thu, Jan 30 2024*
+*Thu, Apr 10, 2025*
 
 🚧 *These notes are under construction while in pre-release* 🚧
 

--- a/additional_notes/0.6.0/header.md
+++ b/additional_notes/0.6.0/header.md
@@ -1,6 +1,3 @@
-
-🚧 *These notes are under construction while in pre-release* 🚧
-
 We’re happy to announce the release of napari 0.6.0! The right-handed release! This release features major changes so read on to see how they might affect you!
 
 napari is a fast, interactive, multi-dimensional image viewer for Python. It’s designed for exploring, annotating, and analyzing multi-dimensional images. It’s built on Qt (for the GUI), VisPy (for performant GPU-based rendering), and the scientific Python stack (NumPy, SciPy, and friends).

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -2,9 +2,9 @@
 
 - Updated viewer handedness ✋
 - Command palette 🎨
-- Display polygons with holes
-- Transition to npe2 plugin engine by default
-- Many other GUI improvements
+- Display polygons with holes ⛳️
+- Transition to npe2 plugin engine by default 🔌
+- Many other GUI improvements 🖥️
 
 ### Updated viewer handedness ✋
 
@@ -36,7 +36,7 @@ like this in previous versions of napari:
 
 ![right shoe rendered as a left shoe in napari](https://github.com/user-attachments/assets/c9190e2c-f35a-44d1-95d5-f9877dd4c843)
 
-and in 0.5.6+, thanks to [#7488](https://github.com/napari/napari/pull/7488):
+and in 0.6.0, thanks to [#7554](https://github.com/napari/napari/pull/7554):
 
 ![right shoe correctly rendered as a right shoe in napari](https://github.com/user-attachments/assets/e187f5e7-8e4a-4526-bae9-80a9bec6fea3)
 
@@ -94,18 +94,17 @@ even works with plugins! This is the culmination of many months of work porting
 napari's actions to Talley Lambert's
 [app-model](https://github.com/pyapp-kit/app-model). 🥳
 
-(video of command palette)
+![command palette example](https://github.com/user-attachments/assets/a412c3d1-8d29-43a2-87a4-391f2ccec57e)
 
 There's still lots of work to be done here, but in the meantime, give it a try!
 We on the team have found it very hard to go back to using napari without the
 palette!
 
-### Feature improvements to Shapes layers
+### Feature improvements to Shapes layers ⛳️
 
-⚠️ *In 0.6.0a1 and earlier, this only works when installing
-PartSegCore-compiled-backend and toggling the "use compiled triangulation"
-option in the advanced preferences. In 0.6.0 it will work with all
-triangulation backends.* ⚠️
+⚠️  *When using numba for triangulation, some shapes will still not be drawn
+correctly, due to a bug in VisPy. We recommend installing `bermuda`, our new
+fast triangulation package, for the best performance.* ⚠️
 
 Finally, napari Shapes layers can now display polygons with holes in them,
 which starts to open it up for use with mapping data, among other things!
@@ -115,7 +114,17 @@ also eliminated a lot of bugs in our polygon drawing code, which could cause
 crashes. If you've had issues with Shapes layers before, now might be a good
 time to give them another try!
 
-### Transition to npe2 plugin engine
+As part of this work, napari gained the ability to select between different
+backends for triangulation, which means breaking up polygons into collections
+of triangles, which is what GPUs are good at drawing.
+([#7747](https://github.com/napari/napari/pull/7747)) To use the new backends,
+install the relevant package (for example, `bermuda`,
+`partsegcore-compiled-backend`, or `numba`), then go to Settings > Experimental
+|> triangulation backend. (If you use `napari[all]`, you will have bermuda
+installed and it will be used automatically, as the default option is "fastest
+available".)
+
+### Transition to npe2 plugin engine 🔌
 
 npe2 was introduced over four years ago, with napari 0.4.12. npe2 has paved the
 way for new plugin functionality, such as [adding menu
@@ -145,7 +154,7 @@ our [Plugins Zulip chat
 channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
 coming to one of our [community meetings](meeting-schedule).
 
-### GUI improvements
+### GUI improvements 🖥️
 
 You'll notice the main napari GUI is subtly (or not so subtly) different in
 0.6.0. Here are some of the improvements:
@@ -165,13 +174,29 @@ You'll notice the main napari GUI is subtly (or not so subtly) different in
 - If you select multiple layers in the layer list, you can now see the status
   display of all the selected layers in the status bar
   ([#7673](https://github.com/napari/napari/pull/7673))
+- If you switch from 2D to 3D view and back again, your 3D viewing angle will
+  be preserved ([#7765](https://github.com/napari/napari/pull/7765))
+- Notice some weird behavior? Our new log handler and viewer might help! Access
+  it with Help > Show logs. ([#6900](https://github.com/napari/napari/pull/6900))
 
 ### Other stuff
 
-For developers: napari now depends on Python 3.10+ and Pydantic v2.2.
+For developers: napari now depends on Python 3.10+
+([#7603](https://github.com/napari/napari/pull/7603) and Pydantic v2.2
+([#7589](https://github.com/napari/napari/pull/7589)).
 
 We've supported both pydantic 1 and 2 since 0.4.19, but we're now ready to take
 advantage of performance and API improvements in Pydantic 2. If your library
 depends on Pydantic 1.x, now would be a good time to upgrade, or it will not be
 compatible with napari going forward.
-([#7589](https://github.com/napari/napari/pull/7589))
+
+
+If you were dreading 0.6.0 because you were relying on `_qt_viewer` features,
+worry not: we have again postponed that deprecation while we add the required
+APIs. 😅 ([#7730](https://github.com/napari/napari/pull/7730))
+
+Also, if you've been wanting to contribute that doc fix but found the process
+daunting, it's now easier than ever, because our default documentation preview
+build is now much faster! You can propose changes from the GitHub UI and see
+the rendered results in only two minutes!
+([napari/docs#669](https://github.com/napari/docs/pull/669))

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -1,3 +1,11 @@
+## Summary - release highlights
+
+- Updated viewer handedness ✋
+- Display polygons with holes
+- New command pallette 🎨
+- Transition to npe2 plugin engine
+
+## New features
 
 ### Updated viewer handedness ✋
 
@@ -38,3 +46,69 @@ implemented workarounds in your code (such as setting the z-scale to a negative
 number), now is a good time to undo the workarounds for newer versions of
 napari! If you run into any issues please get in touch [on GitHub
 issues](https://github.com/napari/napari) or on our [Zulip chat room](https://napari.zulipchat.com)!
+
+### Polygons with holes
+
+Finally, napari is now able to display polygons with holes in them, which starts to open it up for use with mapping data, among other things. Implement polygon with holes in compiled triangulation (#7566)
+
+### Addition of a command palette
+
+The command palette is a new feature that allows you to search for and execute commands in napari. This is a powerful feature that allows you to quickly access and execute commands without having to navigate through the menus. Implement command palette widget (#5483)
+
+### Transition to npe2 plugin engine
+
+npe1 plugins will be automatically converted to npe2 by default (this may break some features if they rely on import-time behaviour).
+npe1 plugins will now be automatically converted to npe2 by default (with a warning), which should not change much but it will break plugins that rely on being imported at launch to modify viewer behaviour. You will be able to turn off this automatic conversion in the settings, but this will go away in 0.7.0 (planned for July),
+so this is your opportunity to work with plugin authors to migrate to npe2.
+
+## Improved modules and features
+
+### Napari core improvements 🧠
+
+- Implement polygon with holes in compiled triangulation (#7566)
+- Add Grid Mode Spacing to change distance between layers (#7597)
+- Add API to Camera model to flip axes (#7663)
+- Flip z axis on 3D camera to default to right-handed frame (#7488 redux) (#7554)
+
+### GUI improvements 🎨
+
+- Implement command palette widget (#5483)
+- Show layer status for all visible layers (#7673)
+- Enable creation of custom linear colormaps in layer controls (#7600)
+- Change ndisplay button to toggle-like to increase discoverability (#7608)
+- Expose additional Camera parameters in GUI with 3D popup widget (#7626)
+- Add right-click indicator to 3D, Roll, Grid, and Square push buttons (#7556)
+- Fix issues displaying polygons with holes in Shapes (#6654)
+
+### Plugins 
+
+Turn on npe2 adaptor by default and add warning (#7627)
+
+npe1 plugins will be automatically converted to npe2 by default (this may break some features if they rely on import-time behaviour).
+npe1 plugins will now be automatically converted to npe2 by default (with a warning), which should not change much but it will break plugins that rely on being imported at launch to modify viewer behaviour.
+You will be able to turn off this automatic conversion in the settings,
+but this will go away in 0.7.0 (planned for July),
+so this is your opportunity to work with plugin authors to migrate to npe2.
+
+### Performance and maintainability
+
+- Pydantic 2.0+ will be required. Remove pydantic v1 compatibility layer, depend on pydantic>=2.2 (#7589) We are requiring Pydantic version 2 and higher. Supporting Pydantic 1 and 2 together was a lot of effort, but by now most plugins and libraries using Pydantic are at version 2, which does bring significant speed and functionality advantages. If you know a library or plugin you use with napari and that is still strictly on Pydantic 1.x, please let us know!
+- Python 3.10+ will be required. Update configuration to drop python 3.9 and add python 3.13 (#7603). We are dropping Python 3.9 support. This is slightly earlier than Python 3.9's EOL date (October 2025), but we are still supporting Python 3.10 which is past its recommended window from SPEC0. The bundle follows SPEC0 strictly and so uses Python 3.11. We hope that serves most if not all of our user community!
+
+### Deprecated
+
+- Pending removal in 0.7.0
+
+### Removed
+
+- Removed deprecated items
+
+## Migrating to napari 0.6.0
+
+For napari 0.6.0a1, we recommend installing the preview release:
+
+```bash
+pip install napari[all] >= 0.6.0a1
+```
+
+*We recommend you update your plugins to npe2. If you have any issues, please let us know!*

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -1,3 +1,11 @@
+# What's new in napari 0.6.0
+
+This note explains the new features and changes in napari 0.6.0.
+
+For full details, see the changelog.
+
+*Note Prerelease users should be aware that this document is currently in draft form. It will be updated substantially as napari 0.6.0 moves towards release, so it’s worth checking back even after reading earlier versions.*
+
 ## Summary - release highlights
 
 - Updated viewer handedness ✋

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -120,7 +120,7 @@ of triangles, which is what GPUs are good at drawing.
 ([#7747](https://github.com/napari/napari/pull/7747)) To use the new backends,
 install the relevant package (for example, `bermuda`,
 `partsegcore-compiled-backend`, or `numba`), then go to Settings > Experimental
-|> triangulation backend. (If you use `napari[all]`, you will have bermuda
+\> triangulation backend. (If you use `napari[all]`, you will have bermuda
 installed and it will be used automatically, as the default option is "fastest
 available".)
 

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -82,7 +82,7 @@ like:
   ![napari settings panel with axis orientation options highlighted](https://github.com/user-attachments/assets/f5032320-8b03-4ff7-9cb7-8b182ab232af)
 
   To restore the orientation from napari 0.5.6 and earlier, change the Depth
-  axis setting to "away" (ie depth axis points away from you).
+  axis setting to "away" (i.e. depth axis points away from you).
 
 ### Command palette 🎨
 
@@ -130,16 +130,18 @@ behavior. ([#7627](https://github.com/napari/napari/pull/7627))
 
 During the 0.6.x series, if some plugin functionality is broken by the
 automatic conversion, you can turn off this conversion in the plugin
-preferences. However, the option to turn not convert npe1 plugins will be
+preferences. However, the option to not convert npe1 plugins will be
 removed in 0.7.0, and npe1 plugins will *only* work through automatic
 conversion. We anticipate 0.7.0 will be released in the second half of 2025.
 
 If you encounter conversion issues in a plugin you rely on, please contact the
 plugin authors to encourage them to migrate their plugin to the npe2 system.
 
-If you are a plugin author and your plugin is not yet npe2-compatible, please
-see our [npe2 migration guide](npe2-migration-guide), and, if you encounter any
-issues, get in touch in our [Plugins Zulip chat
+For more details on this change and how it affects plugins, see the [detailed
+guide](adapted-plugin-guide). If you are a plugin author and your plugin is not
+yet npe2-compatible, please see our [npe2 migration
+guide](npe2-migration-guide), and, if you encounter any issues, get in touch in
+our [Plugins Zulip chat
 channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
 coming to one of our [community meetings](meeting-schedule).
 
@@ -169,7 +171,7 @@ You'll notice the main napari GUI is subtly (or not so subtly) different in
 For developers: napari now depends on Python 3.10+ and Pydantic v2.2.
 
 We've supported both pydantic 1 and 2 since 0.4.19, but we're now ready to take
-advantage of performance and API improvements of Pydantic 2. If your library
+advantage of performance and API improvements in Pydantic 2. If your library
 depends on Pydantic 1.x, now would be a good time to upgrade, or it will not be
 compatible with napari going forward.
 ([#7589](https://github.com/napari/napari/pull/7589))

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -1,19 +1,10 @@
-# What's new in napari 0.6.0
-
-This note explains the new features and changes in napari 0.6.0.
-
-For full details, see the changelog.
-
-*Note Prerelease users should be aware that this document is currently in draft form. It will be updated substantially as napari 0.6.0 moves towards release, so it’s worth checking back even after reading earlier versions.*
-
-## Summary - release highlights
+### Summary
 
 - Updated viewer handedness ✋
+- Command pallette 🎨
 - Display polygons with holes
-- New command pallette 🎨
-- Transition to npe2 plugin engine
-
-## New features
+- Transition to npe2 plugin engine by default
+- Many other GUI improvements
 
 ### Updated viewer handedness ✋
 
@@ -55,68 +46,124 @@ number), now is a good time to undo the workarounds for newer versions of
 napari! If you run into any issues please get in touch [on GitHub
 issues](https://github.com/napari/napari) or on our [Zulip chat room](https://napari.zulipchat.com)!
 
-### Polygons with holes
+On the user space, we now offer several options to orient the axes any way you
+like:
 
-Finally, napari is now able to display polygons with holes in them, which starts to open it up for use with mapping data, among other things. Implement polygon with holes in compiled triangulation (#7566)
+1. **Through the camera API:** the `Viewer.camera` instance gains two new
+  attributes: `orientation`, and `orientation2d`, which is just the last two
+  dimensions of `orientation`. You can set the direction that the *depth*,
+  *vertical*, and *horizontal* axes point to, respectively in that order, as
+  follows ([#7663](https://github.com/napari/napari/pull/7663)):
 
-### Addition of a command palette
+  ```python
+  # 2D
+  viewer.camera.orientation2d = ('up', 'right')
+  # 3D
+  viewer.camera.orientation = ('away', 'up', 'right')
+  ```
 
-The command palette is a new feature that allows you to search for and execute commands in napari. This is a powerful feature that allows you to quickly access and execute commands without having to navigate through the menus. Implement command palette widget (#5483)
+  See an example of this in action in
+  {ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`.
+
+2. By right clicking on the dimension toggle in the viewer, and setting the
+  axis orientations using the drop-down menus
+  ([#7686](https://github.com/napari/napari/pull/7686)), which in 3D will
+  further indicate whether the resulting coordinate frame is [right-handed or
+  left-handed](https://en.wikipedia.org/wiki/Right-hand_rule)
+  ([#7770](https://github.com/napari/napari/pull/7770)):
+
+  ![axis orientation dialog](https://github.com/user-attachments/assets/f73898ec-9156-4f73-ab7f-ee2a7cc17fe1)
+
+3. If you want to use a specific axis orientation consistently, you can set the
+  default orientation on startup by changing the relevant settings
+  ([#7787](https://github.com/napari/napari/pull/7787):
+
+  ![napari settings panel with axis orientation options highlighted](https://github.com/user-attachments/assets/f5032320-8b03-4ff7-9cb7-8b182ab232af)
+
+### Command palette 🎨
+
+Tired of mousing around? Thanks to
+[#5483](https://github.com/napari/napari/pull/5483), napari gains a command
+palette! Press {kbd}`Ctrl/Command+Shift+P` and start typing the name of the
+action you want to use, and press {kbd}`Enter` when you've highlighted it. It
+even works with plugins! This is the culmination of many months of work porting
+napari's actions to Talley Lambert's
+[app-model](https://github.com/pyapp-kit/app-model). 🥳
+
+(video of command palette)
+
+There's still lots of work to be done here, but in the meantime, give it a try!
+We on the team have found it very hard to go back to using napari without the
+palette!
+
+### Feature improvements to Shapes layers
+
+⚠️ *In 0.6.0a1 and earlier, this only works when installing
+PartSegCore-compiled-backend and toggling the "use compiled triangulation"
+option in the advanced preferences. In 0.6.0 it will work wiht all
+triangulation backends.* ⚠️
+
+Finally, napari Shapes layers can now display polygons with holes in them,
+which starts to open it up for use with mapping data, among other things!
+([#7566](https://github.com/napari/napari/pull/7566),
+[#6654](https://github.com/napari/napari/pull/6654)]) Implementing this feature
+also eliminated a lot of bugs in our polygon drawing code, which could cause
+crashes. If you've had issues with Shapes layers before, now might be a good
+time to give them another try!
 
 ### Transition to npe2 plugin engine
 
-npe1 plugins will be automatically converted to npe2 by default (this may break some features if they rely on import-time behaviour).
-npe1 plugins will now be automatically converted to npe2 by default (with a warning), which should not change much but it will break plugins that rely on being imported at launch to modify viewer behaviour. You will be able to turn off this automatic conversion in the settings, but this will go away in 0.7.0 (planned for July),
-so this is your opportunity to work with plugin authors to migrate to npe2.
+npe2 was introduced over four years ago, with napari 0.4.12. npe2 has paved the
+way for new plugin functionality, such as [adding menu
+items](nap-6-contributable-menus) and the command palette. We are now beginning
+the process of deprecating npe1 (napari-plugin-engine) plugins, which we need
+to do to continue to improve npe2 functionality, for example in file readers,
+which is currently very entangled with npe1 code.
 
-## Improved modules and features
+To aid this migration, npe1 plugins will now be automatically converted to npe2
+by default. This may break some features if the plugins relied on import-time
+behavior. ([#7627](https://github.com/napari/napari/pull/7627))
 
-### Napari core improvements 🧠
+During the 0.6.x series, if some plugin functionality is broken by the
+automatic conversion, you can turn off this conversion in the plugin
+preferences. However, this option will go away in 0.7.0, which we anticipate to
+happen sometime in July. Therefore, if you encounter conversion issues in a
+plugin you rely on, please contact the plugin authors to encourage them to
+migrate their plugin to the npe2 system.
 
-- Implement polygon with holes in compiled triangulation (#7566)
-- Add Grid Mode Spacing to change distance between layers (#7597)
-- Add API to Camera model to flip axes (#7663)
-- Flip z axis on 3D camera to default to right-handed frame (#7488 redux) (#7554)
+If you are a plugin author and your plugin is not yet npe2-compatible, please
+see our [npe2 migration guide](npe2-migration-guide), and, if you encounter any
+issues, get in touch in our [Plugins Zulip chat
+channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
+coming to one of our [community meetings](meeting-schedule).
 
-### GUI improvements 🎨
+### GUI improvements
 
-- Implement command palette widget (#5483)
-- Show layer status for all visible layers (#7673)
-- Enable creation of custom linear colormaps in layer controls (#7600)
-- Change ndisplay button to toggle-like to increase discoverability (#7608)
-- Expose additional Camera parameters in GUI with 3D popup widget (#7626)
-- Add right-click indicator to 3D, Roll, Grid, and Square push buttons (#7556)
-- Fix issues displaying polygons with holes in Shapes (#6654)
+You'll notice the main napari GUI is subtly (or not so subtly) different in
+0.6.0. Here are some of the improvements:
 
-### Plugins 
+- Buttons now have an indicator to show whether they contain an extra menu when
+  right-clicking. ([#7556](https://github.com/napari/napari/pull/7556))
+- The button to change between 2D and 3D views much more clearly shows
+  what it does. ([#7608](https://github.com/napari/napari/pull/7608))
+- … And it has an extra menu with lots of options to control the camera!
+  ([#7626](https://github.com/napari/napari/pull/7626))
+- You can now add a bit of spacing between layers in grid mode (and control it
+  in the grid mode right-click menu!)
+  ([#7597](https://github.com/napari/napari/pull/7597))
+- The colormap indicator in image layers is now a button, allowing you to
+  create a linear colormap with any color!
+  ([#7600](https://github.com/napari/napari/pull/7600))
+- If you select multiple layers in the layer list, you can now see the status
+  display of all the selected layers in the status bar
+  ([#7673](https://github.com/napari/napari/pull/7673))
 
-Turn on npe2 adaptor by default and add warning (#7627)
+### Other stuff
 
-npe1 plugins will be automatically converted to npe2 by default (this may break some features if they rely on import-time behaviour).
-npe1 plugins will now be automatically converted to npe2 by default (with a warning), which should not change much but it will break plugins that rely on being imported at launch to modify viewer behaviour.
-You will be able to turn off this automatic conversion in the settings,
-but this will go away in 0.7.0 (planned for July),
-so this is your opportunity to work with plugin authors to migrate to npe2.
+For developers: napari now depends on Python 3.10+ and Pydantic v2.2.
 
-### Performance and maintainability
-
-- Pydantic 2.0+ will be required. Remove pydantic v1 compatibility layer, depend on pydantic>=2.2 (#7589) We are requiring Pydantic version 2 and higher. Supporting Pydantic 1 and 2 together was a lot of effort, but by now most plugins and libraries using Pydantic are at version 2, which does bring significant speed and functionality advantages. If you know a library or plugin you use with napari and that is still strictly on Pydantic 1.x, please let us know!
-- Python 3.10+ will be required. Update configuration to drop python 3.9 and add python 3.13 (#7603). We are dropping Python 3.9 support. This is slightly earlier than Python 3.9's EOL date (October 2025), but we are still supporting Python 3.10 which is past its recommended window from SPEC0. The bundle follows SPEC0 strictly and so uses Python 3.11. We hope that serves most if not all of our user community!
-
-### Deprecated
-
-- Pending removal in 0.7.0
-
-### Removed
-
-- Removed deprecated items
-
-## Migrating to napari 0.6.0
-
-For napari 0.6.0a1, we recommend installing the preview release:
-
-```bash
-pip install napari[all] >= 0.6.0a1
-```
-
-*We recommend you update your plugins to npe2. If you have any issues, please let us know!*
+We've supported both pydantic 1 and 2 since 0.4.19, but we're now ready to take
+advantage of performance and API improvements of Pydantic 2. If your library
+depends on Pydantic 1.x, now would be a good time to upgrade, or it will not be
+compatible with napari going forward.
+([#7589](https://github.com/napari/napari/pull/7589))

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -65,8 +65,8 @@ like:
   See an example of this in action in
   {ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`.
 
-2. By right clicking on the dimension toggle in the viewer, and setting the
-  axis orientations using the drop-down menus
+2. **Through the UI:** By right clicking on the dimension toggle in the viewer,
+  and setting the axis orientations using the drop-down menus
   ([#7686](https://github.com/napari/napari/pull/7686)), which in 3D will
   further indicate whether the resulting coordinate frame is [right-handed or
   left-handed](https://en.wikipedia.org/wiki/Right-hand_rule)
@@ -74,11 +74,15 @@ like:
 
   ![axis orientation dialog](https://github.com/user-attachments/assets/f73898ec-9156-4f73-ab7f-ee2a7cc17fe1)
 
-3. If you want to use a specific axis orientation consistently, you can set the
-  default orientation on startup by changing the relevant settings
+3. **Through the startup settings:** If you want to use a specific axis
+  orientation consistently, you can set the default orientation on startup by
+  changing the relevant settings
   ([#7787](https://github.com/napari/napari/pull/7787):
 
   ![napari settings panel with axis orientation options highlighted](https://github.com/user-attachments/assets/f5032320-8b03-4ff7-9cb7-8b182ab232af)
+
+  To restore the orientation from napari 0.5.6 and earlier, change the Depth
+  axis setting to "away" (ie depth axis points away from you).
 
 ### Command palette 🎨
 
@@ -126,10 +130,12 @@ behavior. ([#7627](https://github.com/napari/napari/pull/7627))
 
 During the 0.6.x series, if some plugin functionality is broken by the
 automatic conversion, you can turn off this conversion in the plugin
-preferences. However, this option will go away in 0.7.0, which we anticipate to
-happen sometime in July. Therefore, if you encounter conversion issues in a
-plugin you rely on, please contact the plugin authors to encourage them to
-migrate their plugin to the npe2 system.
+preferences. However, the option to turn not convert npe1 plugins will be
+removed in 0.7.0, and npe1 plugins will *only* work through automatic
+conversion. We anticipate 0.7.0 will be released in the second half of 2025.
+
+If you encounter conversion issues in a plugin you rely on, please contact the
+plugin authors to encourage them to migrate their plugin to the npe2 system.
 
 If you are a plugin author and your plugin is not yet npe2-compatible, please
 see our [npe2 migration guide](npe2-migration-guide), and, if you encounter any

--- a/additional_notes/0.6.0/highlights.md
+++ b/additional_notes/0.6.0/highlights.md
@@ -1,7 +1,7 @@
 ### Summary
 
 - Updated viewer handedness ✋
-- Command pallette 🎨
+- Command palette 🎨
 - Display polygons with holes
 - Transition to npe2 plugin engine by default
 - Many other GUI improvements
@@ -100,7 +100,7 @@ palette!
 
 ⚠️ *In 0.6.0a1 and earlier, this only works when installing
 PartSegCore-compiled-backend and toggling the "use compiled triangulation"
-option in the advanced preferences. In 0.6.0 it will work wiht all
+option in the advanced preferences. In 0.6.0 it will work with all
 triangulation backends.* ⚠️
 
 Finally, napari Shapes layers can now display polygons with holes in them,

--- a/env.yml
+++ b/env.yml
@@ -11,3 +11,4 @@ dependencies:
 - unidecode
 - pyyaml
 - argcomplete
+- pre-commit

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -290,7 +290,7 @@ print(
     file=file_handle,
 )
 print('*', file=file_handle)
-print(milestone_obj.due_on.strftime('%A, %b %d, %Y'), file=file_handle)
+print(milestone_obj.due_on.strftime('%a, %b %d, %Y'), file=file_handle)
 print('*', file=file_handle)
 
 if (fn := notes_dir / 'header.md').exists():

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -289,9 +289,9 @@ print(
     f'⚠️ *Note: these release notes are still in draft while {args.milestone} is in release candidate testing.* ⚠️',
     file=file_handle,
 )
-print('', file=file_handle)
+print('*', file=file_handle)
 print(milestone_obj.due_on.strftime('%A, %b %d, %Y'), file=file_handle)
-print('', file=file_handle)
+print('*', file=file_handle)
 
 if (fn := notes_dir / 'header.md').exists():
     intro = fn.open().read()


### PR DESCRIPTION
I've added some detail shared by @jni and @Czaki to this draft note and grouped some items for user readability. I modeled the sections after how we organize Python releases.

It's still needs more editing but it's better than what we had for 0.6.0a0. I would recommend merging and iterating on the note over the rest of this week.