### PR TITLE
Add PR with highlight label from docs repo to highlight section of release notes

### DIFF
--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -243,6 +243,11 @@ for pull in iter_pull_request(
             docs_reviewers.add(review.user.login)
     assigned_to_section = False
     pr_labels = {label.name.lower() for label in pull.labels}
+    if 'highlight' in pr_labels:
+        highlights['Highlights'][pull.number] = {
+            'summary': summary,
+            'repo': GH_DOCS_REPO,
+        }
     if 'maintenance' in pr_labels:
         other_pull_requests[pull.number] = {
             'summary': summary,


### PR DESCRIPTION
I cannot find it but remember that in some issue @jni and @TimMonko spot that docs PR with highlight label are not added to the highlight section. 

	