### PR TITLE
Fix release utils for proper name correction on Windows

### DIFF
--- a/release_utils.py
+++ b/release_utils.py
@@ -232,12 +232,10 @@ def get_correction_dict(file_path: Path | None) -> dict[str, str]:
         return {}
 
     correction_dict = {}
-    with open(file_path) as f:
+    with open(file_path, encoding='utf-8') as f:
         corrections = safe_load(f)
         for correction in corrections['login_to_name']:
-            correction_dict[correction['login']] = unidecode(
-                correction['corrected_name'].lower()
-            )
+            correction_dict[correction['login']] = correction['corrected_name']
 
     return correction_dict
 


### PR DESCRIPTION
These changes use proper encoding for Windows to properly use names from the `name_correction.yaml` when generating release notes. Without `utf-8` it returns the original github name, and by removing `lower()` it keeps the names as-is from the name corrections file.
I'm actually surprised the `lower()` wasn't an issue on unix machines previously. 🤷 