### PR TITLE
Speedup generate_release_notes script by using threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 issue.md
 github_cache.sqlite
+github_cache/*
 napari_repo
 project_repo
 .python-version

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -64,8 +64,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
 
-from github.PullRequest import PullRequest
-from github.Repository import Repository
 from packaging.version import parse as parse_version
 
 from release_utils import (
@@ -196,15 +194,15 @@ label_to_section = {
 }
 
 
-def parse_pull(pull: PullRequest, repo_: Repository = repo):
-    # assert pull.merged or pull.number in args.with_pr
+def parse_pull(pull_number: int, repo_full_name: str):
+    repo_ = get_repo(*repo_full_name.split('/'))
+    pull = repo_.get_pull(pull_number)
+
     is_merged = pull.raw_data.get('merged')
     if is_merged is None:
-        # Fallback if raw_data doesn't have it, though as_pull_request usually does
         is_merged = pull.merged
 
     if is_merged:
-        # Use merged_by and user from raw_data if possible to avoid extra API calls
         if pull.merged_by is not None:
             add_to_users(users, pull.merged_by)
             committers.add(pull.merged_by.login)
@@ -222,16 +220,16 @@ def parse_pull(pull: PullRequest, repo_: Repository = repo):
     pr_labels = {label.name.lower() for label in pull.labels}
     for label_name, section in label_to_section.items():
         if label_name in pr_labels:
-            highlights[section][pull.number] = {
+            highlights[section][pull_number] = {
                 'summary': summary,
-                'repo': repo_.full_name.split('/')[1],
+                'repo': repo_full_name.split('/')[1],
             }
             assigned_to_section = True
 
     if not assigned_to_section:
-        other_pull_requests[pull.number] = {
+        other_pull_requests[pull_number] = {
             'summary': summary,
-            'repo': repo_.full_name.split('/')[1],
+            'repo': repo_full_name.split('/')[1],
         }
 
 
@@ -242,18 +240,15 @@ for pull_ in iter_pull_request(f'milestone:{args.milestone} {args.merged}'):
         is_merged = pull_.merged
     if not is_merged:
         non_merged_pr.append(pull_)
-    pulls_to_parse.append((pull_, repo))
+    pulls_to_parse.append((pull_.number, repo.full_name))
 
 if args.with_pr is not None:
     for pr_num in args.with_pr:
         if isinstance(pr_num, int):
-            pull = repo.get_pull(pr_num)
-            r = repo
+            pulls_to_parse.append((pr_num, repo.full_name))
         else:
             r = get_repo(pr_num.user, pr_num.repo)
-            pull = r.get_pull(pr_num.pr)
-
-        pulls_to_parse.append((pull, r))
+            pulls_to_parse.append((pr_num.pr, r.full_name))
 
 doc_pulls = list(
     iter_pull_request(
@@ -269,7 +264,7 @@ for pull in doc_pulls:
         non_merged_pr.append(pull)
 
 with ThreadPoolExecutor(max_workers=10) as executor:
-    executor.map(lambda x: parse_pull(*x), pulls_to_parse)
+    list(executor.map(lambda x: parse_pull(*x), pulls_to_parse))
 
 for pull in doc_pulls:
     issue = pull.as_issue()

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -60,7 +60,6 @@ References:
 import argparse
 import re
 import sys
-import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
@@ -81,6 +80,7 @@ from release_utils import (
     get_milestone,
     get_repo,
     iter_pull_request,
+    setup_cache,
 )
 
 LOCAL_DIR = Path(__file__).parent
@@ -137,7 +137,7 @@ version = parse_version(args.tag)
 args.milestone = version.base_version
 
 
-# setup_cache()
+setup_cache()
 repo = get_repo()
 correction_dict = get_correction_dict(
     args.correction_file
@@ -146,20 +146,16 @@ correction_dict = get_correction_dict(
 )
 
 
-users_lock = threading.Lock()
-
-
 def add_to_users(users_dkt, new_user):
-    with users_lock:
-        if new_user.login in users_dkt:
-            # reduce obsolete requests to GitHub API
-            return
-        if new_user.login in correction_dict:
-            users_dkt[new_user.login] = correction_dict[new_user.login]
-        elif new_user.name is None:
-            users_dkt[new_user.login] = new_user.login
-        else:
-            users_dkt[new_user.login] = new_user.name
+    if new_user.login in users_dkt:
+        # reduce obsolete requests to GitHub API
+        return
+    if new_user.login in correction_dict:
+        users_dkt[new_user.login] = correction_dict[new_user.login]
+    elif new_user.name is None:
+        users_dkt[new_user.login] = new_user.login
+    else:
+        users_dkt[new_user.login] = new_user.name
 
 
 authors = set()
@@ -211,37 +207,32 @@ def parse_pull(pull: PullRequest, repo_: Repository = repo):
         # Use merged_by and user from raw_data if possible to avoid extra API calls
         if pull.merged_by is not None:
             add_to_users(users, pull.merged_by)
-            with users_lock:
-                committers.add(pull.merged_by.login)
+            committers.add(pull.merged_by.login)
         if pull.user is not None:
             add_to_users(users, pull.user)
-            with users_lock:
-                authors.add(pull.user.login)
+            authors.add(pull.user.login)
 
     summary = pull.title
 
     for review in pull.get_reviews():
         if review.user is not None:
             add_to_users(users, review.user)
-            with users_lock:
-                reviewers.add(review.user.login)
+            reviewers.add(review.user.login)
     assigned_to_section = False
     pr_labels = {label.name.lower() for label in pull.labels}
     for label_name, section in label_to_section.items():
         if label_name in pr_labels:
-            with users_lock:
-                highlights[section][pull.number] = {
-                    'summary': summary,
-                    'repo': repo_.full_name.split('/')[1],
-                }
-            assigned_to_section = True
-
-    if not assigned_to_section:
-        with users_lock:
-            other_pull_requests[pull.number] = {
+            highlights[section][pull.number] = {
                 'summary': summary,
                 'repo': repo_.full_name.split('/')[1],
             }
+            assigned_to_section = True
+
+    if not assigned_to_section:
+        other_pull_requests[pull.number] = {
+            'summary': summary,
+            'repo': repo_.full_name.split('/')[1],
+        }
 
 
 pulls_to_parse = []
@@ -293,8 +284,7 @@ for pull in doc_pulls:
         for review in reviews:
             if review.user is not None:
                 add_to_users(users, review.user)
-                with users_lock:
-                    docs_reviewers.add(review.user.login)
+                docs_reviewers.add(review.user.login)
 
     assigned_to_section = False
     pr_labels = {label.name.lower() for label in pull.labels}

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -60,6 +60,8 @@ References:
 import argparse
 import re
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
 
@@ -79,7 +81,6 @@ from release_utils import (
     get_milestone,
     get_repo,
     iter_pull_request,
-    setup_cache,
 )
 
 LOCAL_DIR = Path(__file__).parent
@@ -136,7 +137,7 @@ version = parse_version(args.tag)
 args.milestone = version.base_version
 
 
-setup_cache()
+# setup_cache()
 repo = get_repo()
 correction_dict = get_correction_dict(
     args.correction_file
@@ -145,16 +146,20 @@ correction_dict = get_correction_dict(
 )
 
 
+users_lock = threading.Lock()
+
+
 def add_to_users(users_dkt, new_user):
-    if new_user.login in users_dkt:
-        # reduce obsolete requests to GitHub API
-        return
-    if new_user.login in correction_dict:
-        users_dkt[new_user.login] = correction_dict[new_user.login]
-    elif new_user.name is None:
-        users_dkt[new_user.login] = new_user.login
-    else:
-        users_dkt[new_user.login] = new_user.name
+    with users_lock:
+        if new_user.login in users_dkt:
+            # reduce obsolete requests to GitHub API
+            return
+        if new_user.login in correction_dict:
+            users_dkt[new_user.login] = correction_dict[new_user.login]
+        elif new_user.name is None:
+            users_dkt[new_user.login] = new_user.login
+        else:
+            users_dkt[new_user.login] = new_user.name
 
 
 authors = set()
@@ -197,44 +202,56 @@ label_to_section = {
 
 def parse_pull(pull: PullRequest, repo_: Repository = repo):
     # assert pull.merged or pull.number in args.with_pr
+    is_merged = pull.raw_data.get('merged')
+    if is_merged is None:
+        # Fallback if raw_data doesn't have it, though as_pull_request usually does
+        is_merged = pull.merged
 
-    if pull.is_merged():
-        commit = repo_.get_commit(pull.merge_commit_sha)
-
-        if commit.committer is not None:
-            add_to_users(users, commit.committer)
-            committers.add(commit.committer.login)
-        if commit.author is not None:
-            add_to_users(users, commit.author)
-            authors.add(commit.author.login)
+    if is_merged:
+        # Use merged_by and user from raw_data if possible to avoid extra API calls
+        if pull.merged_by is not None:
+            add_to_users(users, pull.merged_by)
+            with users_lock:
+                committers.add(pull.merged_by.login)
+        if pull.user is not None:
+            add_to_users(users, pull.user)
+            with users_lock:
+                authors.add(pull.user.login)
 
     summary = pull.title
 
     for review in pull.get_reviews():
         if review.user is not None:
             add_to_users(users, review.user)
-            reviewers.add(review.user.login)
+            with users_lock:
+                reviewers.add(review.user.login)
     assigned_to_section = False
     pr_labels = {label.name.lower() for label in pull.labels}
     for label_name, section in label_to_section.items():
         if label_name in pr_labels:
-            highlights[section][pull.number] = {
-                'summary': summary,
-                'repo': repo_.full_name.split('/')[1],
-            }
+            with users_lock:
+                highlights[section][pull.number] = {
+                    'summary': summary,
+                    'repo': repo_.full_name.split('/')[1],
+                }
             assigned_to_section = True
 
     if not assigned_to_section:
-        other_pull_requests[pull.number] = {
-            'summary': summary,
-            'repo': repo_.full_name.split('/')[1],
-        }
+        with users_lock:
+            other_pull_requests[pull.number] = {
+                'summary': summary,
+                'repo': repo_.full_name.split('/')[1],
+            }
 
 
+pulls_to_parse = []
 for pull_ in iter_pull_request(f'milestone:{args.milestone} {args.merged}'):
-    if not pull_.is_merged():
+    is_merged = pull_.raw_data.get('merged')
+    if is_merged is None:
+        is_merged = pull_.merged
+    if not is_merged:
         non_merged_pr.append(pull_)
-    parse_pull(pull_)
+    pulls_to_parse.append((pull_, repo))
 
 if args.with_pr is not None:
     for pr_num in args.with_pr:
@@ -245,24 +262,40 @@ if args.with_pr is not None:
             r = get_repo(pr_num.user, pr_num.repo)
             pull = r.get_pull(pr_num.pr)
 
-        parse_pull(pull, r)
+        pulls_to_parse.append((pull, r))
 
-for pull in iter_pull_request(
-    f'milestone:{args.milestone} {args.merged}', repo=GH_DOCS_REPO
-):
-    issue = pull.as_issue()
-    if not pull.is_merged():
+doc_pulls = list(
+    iter_pull_request(
+        f'milestone:{args.milestone} {args.merged}', repo=GH_DOCS_REPO
+    )
+)
+
+for pull in doc_pulls:
+    is_merged = pull.raw_data.get('merged')
+    if is_merged is None:
+        is_merged = pull.merged
+    if not is_merged:
         non_merged_pr.append(pull)
 
+with ThreadPoolExecutor(max_workers=10) as executor:
+    executor.map(lambda x: parse_pull(*x), pulls_to_parse)
+
+for pull in doc_pulls:
+    issue = pull.as_issue()
     add_to_users(users, issue.user)
     docs_authors.add(issue.user.login)
 
     summary = pull.title
 
-    for review in pull.get_reviews():
-        if review.user is not None:
-            add_to_users(users, review.user)
-            docs_reviewers.add(review.user.login)
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        # We need reviews for docs PRs too
+        reviews = list(pull.get_reviews())
+        for review in reviews:
+            if review.user is not None:
+                add_to_users(users, review.user)
+                with users_lock:
+                    docs_reviewers.add(review.user.login)
+
     assigned_to_section = False
     pr_labels = {label.name.lower() for label in pull.labels}
     if 'highlight' in pr_labels:

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -127,7 +127,7 @@ parser.add_argument(
     dest='merged',
 )
 parser.add_argument(
-    '--disable-cache',
+    '--no-cache',
     help='Disable caching of GitHub API requests. This may lead to slower execution and more requests to the GitHub API, but ensures that you are getting the most up-to-date information.',
     action='store_true',
 )
@@ -139,7 +139,7 @@ version = parse_version(args.tag)
 
 args.milestone = version.base_version
 
-if not args.disable_cache:
+if not args.no_cache:
     setup_cache()
 repo = get_repo()
 correction_dict = get_correction_dict(

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -126,6 +126,11 @@ parser.add_argument(
     default='',
     dest='merged',
 )
+parser.add_argument(
+    '--disable-cache',
+    help='Disable caching of GitHub API requests. This may lead to slower execution and more requests to the GitHub API, but ensures that you are getting the most up-to-date information.',
+    action='store_true',
+)
 
 args = parser.parse_args()
 
@@ -134,8 +139,8 @@ version = parse_version(args.tag)
 
 args.milestone = version.base_version
 
-
-setup_cache()
+if not args.disable_cache:
+    setup_cache()
 repo = get_repo()
 correction_dict = get_correction_dict(
     args.correction_file
@@ -420,8 +425,9 @@ for section, pull_request_dicts in highlights.items():
         for pr_number in pr_number_pattern.findall(text):
             mentioned_pr.add(int(pr_number))
         print(text, file=file_handle)
+        print('', file=file_handle)
 
-    for number, pull_request_info in pull_request_dicts.items():
+    for number, pull_request_info in sorted(pull_request_dicts.items(), key=lambda x: x[0]):
         if number in mentioned_pr:
             continue
         repo_str = pull_request_info['repo']

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -427,7 +427,9 @@ for section, pull_request_dicts in highlights.items():
         print(text, file=file_handle)
         print('', file=file_handle)
 
-    for number, pull_request_info in sorted(pull_request_dicts.items(), key=lambda x: x[0]):
+    for number, pull_request_info in sorted(
+        pull_request_dicts.items(), key=lambda x: x[0]
+    ):
         if number in mentioned_pr:
             continue
         repo_str = pull_request_info['repo']

--- a/release_utils.py
+++ b/release_utils.py
@@ -4,13 +4,12 @@ import contextlib
 import os
 import re
 import sys
+import threading
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
 from git import Repo
-import threading
-
 from github import Github, Milestone
 from tqdm import tqdm
 from unidecode import unidecode

--- a/release_utils.py
+++ b/release_utils.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from pathlib import Path
 
 from git import Repo
+import threading
+
 from github import Github, Milestone
 from tqdm import tqdm
 from unidecode import unidecode
@@ -70,12 +72,11 @@ GH_REPO = os.environ.get('GH_REPO', 'napari')
 GH_DOCS_REPO = os.environ.get('GH_REPO', 'docs')
 GH_TOKEN = os.environ.get('GH_TOKEN')
 
-_G = None
+_thread_local = threading.local()
 
 
 def get_github():
-    global _G
-    if _G is None:
+    if not hasattr(_thread_local, 'github'):
         if GH_TOKEN is None:
             raise RuntimeError(
                 'It is necessary that the environment variable `GH_TOKEN` '
@@ -84,8 +85,8 @@ def get_github():
                 'You do not need to select any permission boxes while generating '
                 'the token.'
             )
-        _G = Github(GH_TOKEN)
-    return _G
+        _thread_local.github = Github(GH_TOKEN)
+    return _thread_local.github
 
 
 def get_repo(user=GH_USER, repo=GH_REPO):

--- a/release_utils.py
+++ b/release_utils.py
@@ -55,7 +55,10 @@ def setup_cache(timeout=3600):
 
     """setup cache for requests"""
     requests_cache.install_cache(
-        'github_cache', backend='sqlite', expire_after=timeout
+        'github_cache',
+        backend='filesystem',
+        expire_after=timeout,
+        allowable_methods=['GET', 'POST'],
     )
 
 

--- a/release_utils.py
+++ b/release_utils.py
@@ -158,12 +158,14 @@ def iter_pull_request(additional_query, user=GH_USER, repo=GH_REPO):
         f' for repo {user}/{repo}',
         file=sys.stderr,
     )
-    for pull_issue in tqdm(
-        iterable,
-        desc=f'Pull Requests ({user}/{repo})...',
-        total=iterable.totalCount,
-    ):
-        yield pull_issue.as_pull_request()
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        yield from tqdm(
+            executor.map(lambda x: x.as_pull_request(), iterable),
+            desc=f'Pull Requests ({user}/{repo})...',
+            total=iterable.totalCount,
+        )
 
 
 def get_pr_commits_dict(repo: Repo, branch: str = 'main') -> dict[int, str]:

--- a/release_utils.py
+++ b/release_utils.py
@@ -224,6 +224,7 @@ BOT_LIST = {
     'github-actions[bot]',
     'pre-commit-ci[bot]',
     'dependabot[bot]',
+    'github-advanced-security[bot]',
     'napari-bot',
     None,
 }


### PR DESCRIPTION
Speed up generation of release notes by using threading. 

for current state of 0.7.1 
main 3m30s 
PR 30s 


0.7.0 
main 10m
PR 1m27s

Stop using SQLite as a cache backend, as it do not work well with threads; use filesystem cache instead.  