### PR TITLE
Add breaking changes section, add examples to documentation

### DIFF
--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -187,6 +187,7 @@ non_merged_pr = []
 highlights = {
     'Highlights': {},
     'New Features': {},
+    'Breaking Changes': {},
     'Improvements': {},
     'Performance': {},
     'Bug Fixes': {},
@@ -209,6 +210,8 @@ label_to_section = {
     'deprecation': 'Deprecations',
     'dependencies': 'Build Tools',
     'documentation': 'Documentation',
+    'example': 'Documentation',
+    'release:breaking change': 'Breaking Changes',
 }
 
 


### PR DESCRIPTION
This PR adds a “Breaking changes” section to the release notes, just behind new features. 

This allows better signaling that some changes are breaking without putting it in the highlights, which is crowded recently. 

If we need, we could still provide longer descriptions, as for all sections. 

This PR also adds all PRs labeled as examples to the documentation section. For me, each example is a part of documentation. 